### PR TITLE
removed repeat information from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,9 @@ Checkpoint benchmarks were taken on a single GCE `n2d-standard-48` node co-locat
 | Without Connector   | 6.5 B  | 24,200| 2,093.52  | 11.56   |
 | Connector           | 6.5 B  | 24,200| 113.14    | 213.89  |
 
-## Limitations
+## Additional Technical Limitations
+
+For more detail on technical limitations please see our [official documentation](https://cloud.google.com/storage/docs/pytorch-connector).
 
 ### Composite Objects
 To optimize the download performance of small files, the Connector for PyTorch library utilizes the [GCS Compose API](https://cloud.google.com/storage/docs/json_api/v1/objects/compose) to concatenate a set of smaller objects into a new and larger one in the same bucket under a folder named “dataflux-composed-objects”. The new composite objects will be removed at the end of your training loop but in rare cases that they don’t, you can run this command to clean the composed files.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Storage Connector for PyTorch
 
-The Cloud Storage Connector for PyTorch lets you connect directly to a GCS bucket as a PyTorch dataset, without pre-loading the data to local disk, and with optimizations to make training up to **3X faster** when the dataset consists of many small files (e.g., 100 - 500 KB).
+Cloud Storage's Connector for PyTorch is an open source product supported by Google that provides a direct Cloud Storage integration with PyTorch. To learn more, see the official documentation [here](https://cloud.google.com/storage/docs/pytorch-connector).
 
 The Connector for PyTorch implements PyTorch’s [dataset primitive](https://pytorch.org/tutorials/beginner/basics/data_tutorial.html) that can be used to efficiently load training data from GCS. The library currently supports [map-style datasets](https://pytorch.org/docs/stable/data.html#map-style-datasets) for random data access patterns and [iterable-style datasets](https://pytorch.org/docs/stable/data.html#iterable-style-datasets) for streaming data access patterns.
 


### PR DESCRIPTION
Removed repeat documentation from main REAME. Documentation with slight repeats that require code examples have been left in to preserve clarity for users.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR