### PR TITLE
Latest pytorch version

### DIFF
--- a/dataflux_pytorch/benchmark/requirements.txt
+++ b/dataflux_pytorch/benchmark/requirements.txt
@@ -1,2 +1,2 @@
-torch==2.3.1
+torch
 gcsfs

--- a/demo/lightning/checkpoint/requirements.txt
+++ b/demo/lightning/checkpoint/requirements.txt
@@ -1,2 +1,2 @@
-torch==2.3.1
+torch
 gcsfs


### PR DESCRIPTION
Fixes  https://github.com/GoogleCloudPlatform/gcs-connector-for-pytorch/security/dependabot/2
The vulnerability arises in torch  2.3.1 version. Changing it to the latest version. 
- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR